### PR TITLE
add citation information for the gdverse package

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -28,6 +28,7 @@ knitr::opts_chunk$set(
 [![R-CMD-check](https://github.com/stscl/gdverse/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/stscl/gdverse/actions/workflows/R-CMD-check.yaml)
 [![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-20b2aa.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
 [![R-universe](https://stscl.r-universe.dev/badges/gdverse?color=cyan)](https://stscl.r-universe.dev/gdverse)
+[![DOI](https://img.shields.io/badge/DOI-10.1111%2Ftgis.70032-63847e?logo=doi&style=flat)](https://onlinelibrary.wiley.com/doi/10.1111/tgis.70032)
 
 <!-- badges: end -->
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Checks](https://badges.cranchecks.info/worst/gdverse.svg)](https://cran.r-projec
 [![Lifecycle:
 stable](https://img.shields.io/badge/lifecycle-stable-20b2aa.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
 [![R-universe](https://stscl.r-universe.dev/badges/gdverse?color=cyan)](https://stscl.r-universe.dev/gdverse)
+[![DOI](https://img.shields.io/badge/DOI-10.1111%2Ftgis.70032-63847e?logo=doi&style=flat)](https://onlinelibrary.wiley.com/doi/10.1111/tgis.70032)
 
 <!-- badges: end -->
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,13 @@
+citHeader("To cite gdverse package in publications use:")
+
+bibentry(
+  bibtype  = "Article",
+  title    = "gdverse: An R Package for Spatial Stratified Heterogeneity Family",
+  author   = "Lv, Wenbo and Lei, Yangyang and Liu, Fangmei and Yan, Jianwu and Song, Yongze and Zhao, Wufan",
+  journal  = "Transactions in GIS",
+  year     = "2025",
+  volume   = "29",
+  number   = "2",
+  pages    = "29:e70032",
+  doi      = "10.1111/tgis.70032"
+)


### PR DESCRIPTION
The paper introducing the `gdverse` package has been accepted by *Transactions in GIS* and can be accessed at <https://onlinelibrary.wiley.com/doi/10.1111/tgis.70032>. In this PR, I have added the corresponding citation information.
- Add a badge for the article DOI in the package README.
- Add the package paper information to the corresponding citation (page numbers are not available yet).